### PR TITLE
Fix alarm reference in the dashboard

### DIFF
--- a/aws/application/monitoring_stack.template
+++ b/aws/application/monitoring_stack.template
@@ -678,7 +678,7 @@ Resources:
                   "title" : "Application ELB Queries Per Minute",
                   "annotations": {
                     "alarms": [
-                      "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${RDSQueryLatencyOverThreshold}"
+                      "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${RequestCountOverThreshold}"
                     ]
                   },
                   "view": "timeSeries",


### PR DESCRIPTION
The dashboard widget was displaying RDS Query latency, rather than load
balancer request count.